### PR TITLE
Adds support for OpenAlex api_key request parameter

### DIFF
--- a/pyalex/api.py
+++ b/pyalex/api.py
@@ -17,7 +17,7 @@ class AlexConfig(dict):
         return super().__setitem__(key, value)
 
 
-config = AlexConfig(email=None, openalex_url="https://api.openalex.org")
+config = AlexConfig(email=None, api_key=None, openalex_url="https://api.openalex.org")
 
 
 def _flatten_kv(k, v):
@@ -163,9 +163,11 @@ class BaseOpenAlex(object):
             return self._get_multi_items(record_id)
 
         url = self.url + "/" + record_id
-
+        params = {"api_key": config.api_key} if config.api_key else {}
         res = requests.get(
-            url, headers={"User-Agent": "pyalex/" + __version__, "email": config.email}
+            url,
+            headers={"User-Agent": "pyalex/" + __version__, "email": config.email},
+            params=params
         )
         res.raise_for_status()
         res_json = res.json()
@@ -191,13 +193,16 @@ class BaseOpenAlex(object):
                 l.append(k + "=" + quote_plus(str(v)))
 
         url = self.url + "?" + "&".join(l)
-
+        params = {"api_key": config.api_key} if config.api_key else {}
         res = requests.get(
-            url, headers={"User-Agent": "pyalex/" + __version__, "email": config.email}
+            url,
+            headers={"User-Agent": "pyalex/" + __version__, "email": config.email},
+            params=params
         )
         res_json = res.json()
 
-        if res.status_code == 403 and "query parameters" in res_json["error"]:
+        # Removed "query parameters" in res_json["error"] as res_json["error"] is a boolean
+        if res.status_code == 403:
             raise QueryError(res_json["message"])
 
         res.raise_for_status()

--- a/pyalex/api.py
+++ b/pyalex/api.py
@@ -215,8 +215,7 @@ class BaseOpenAlex(object):
         )
         res_json = res.json()
 
-        # Removed "query parameters" in res_json["error"] as res_json["error"] is a boolean
-        if res.status_code == 403:
+        if res.status_code == 403 and "query parameters" in res_json["error"]:
             raise QueryError(res_json["message"])
 
         res.raise_for_status()

--- a/tests/test_pyalex.py
+++ b/tests/test_pyalex.py
@@ -19,7 +19,7 @@ def test_config():
     assert pyalex.config.email == "myemail@example.com"
     assert pyalex.config.api_key is None
     pyalex.config.api_key = "my_api_key"
-    assert pyalex.config.api_key is "my_api_key"
+    assert pyalex.config.api_key == "my_api_key"
 
 
 def test_meta_entities():

--- a/tests/test_pyalex.py
+++ b/tests/test_pyalex.py
@@ -14,10 +14,12 @@ from pyalex import Works
 
 
 def test_config():
-
     pyalex.config.email = "myemail@example.com"
 
     assert pyalex.config.email == "myemail@example.com"
+    assert pyalex.config.api_key is None
+    pyalex.config.api_key = "my_api_key"
+    assert pyalex.config.api_key is "my_api_key"
 
 
 def test_meta_entities():

--- a/tests/test_pyalex.py
+++ b/tests/test_pyalex.py
@@ -20,6 +20,7 @@ def test_config():
     assert pyalex.config.api_key is None
     pyalex.config.api_key = "my_api_key"
     assert pyalex.config.api_key == "my_api_key"
+    pyalex.config.api_key = None
 
 
 def test_meta_entities():


### PR DESCRIPTION
OpenAlex provides an `api_key` query parameter that provides additional functionality and more frequent updates to commercial customers.

This PR adds `api_key` support to pyalex. Just set `config.api_key` to your API key value.