### PR TITLE
Update api.py with docstring for paginate 

### DIFF
--- a/pyalex/api.py
+++ b/pyalex/api.py
@@ -305,7 +305,7 @@ class BaseOpenAlex:
                 Defaults to 10000.
 
         Returns:
-            CursorPaginator: Itterator to use for returning and processing each page 
+            CursorPaginator: Iterator to use for returning and processing each page 
             result in sequence. 
         """
         return CursorPaginator(self, per_page=per_page, cursor=cursor, n_max=n_max)

--- a/pyalex/api.py
+++ b/pyalex/api.py
@@ -292,7 +292,22 @@ class BaseOpenAlex:
             return results
 
     def paginate(self, per_page=None, cursor="*", n_max=10000):
+        """Used for paging results of large responses using cursor paging. 
+        
+        OpenAlex offers two methods for paging: basic paging and cursor paging. 
+        Both methods are supported by PyAlex, although cursor paging seems to be 
+        easier to implement and less error-prone.
 
+        Args:
+            per_page (_type_, optional): Entries per page to return. Defaults to None.
+            cursor (str, optional): _description_. Defaults to "*".
+            n_max (int, optional): Number of max results (not pages) to return. 
+                Defaults to 10000.
+
+        Returns:
+            CursorPaginator: Itterator to use for returning and processing each page 
+            result in sequence. 
+        """
         return CursorPaginator(self, per_page=per_page, cursor=cursor, n_max=n_max)
 
     def random(self):


### PR DESCRIPTION
Added docstring to paginate to explain what n_max is and the function does. 


        """Used for paging results of large responses using cursor paging. 
        
        OpenAlex offers two methods for paging: basic paging and cursor paging. 
        Both methods are supported by PyAlex, although cursor paging seems to be 
        easier to implement and less error-prone.

        Args:
            per_page (_type_, optional): Entries per page to return. Defaults to None.
            cursor (str, optional): _description_. Defaults to "*".
            n_max (int, optional): Number of max results (not pages) to return. 
                Defaults to 10000.

        Returns:
            CursorPaginator: Itterator
        """