### PR TITLE
Fix unknown import `openalex`

### DIFF
--- a/pyalex/api.py
+++ b/pyalex/api.py
@@ -5,7 +5,7 @@ from urllib.parse import quote_plus
 import requests
 
 try:
-    from openalex._version import __version__
+    from pyalex._version import __version__
 except ImportError:
     __version__ = "0.0.0"
 


### PR DESCRIPTION
Change the version import at the start of `api.py` from `openalex` to `pyalex`.

I assume this is a typo/old version, since I can't find any reference to an `openalex` module.