### PR TITLE
Added support for Topics

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,10 +45,10 @@ pip install pyalex
 
 ## Getting started
 
-PyAlex offers support for all [Entity Objects](https://docs.openalex.org/api-entities/entities-overview): [Works](https://docs.openalex.org/api-entities/works), [Authors](https://docs.openalex.org/api-entities/authors), [Sources](https://docs.openalex.org/api-entities/sourcese), [Institutions](https://docs.openalex.org/api-entities/institutions), [Concepts](https://docs.openalex.org/api-entities/concepts), [Publishers](https://docs.openalex.org/api-entities/publishers), and [Funders](https://docs.openalex.org/api-entities/funders).
+PyAlex offers support for all [Entity Objects](https://docs.openalex.org/api-entities/entities-overview): [Works](https://docs.openalex.org/api-entities/works), [Authors](https://docs.openalex.org/api-entities/authors), [Sources](https://docs.openalex.org/api-entities/sourcese), [Institutions](https://docs.openalex.org/api-entities/institutions), [Concepts](https://docs.openalex.org/api-entities/concepts), [Topics](https://docs.openalex.org/api-entities/topics), [Publishers](https://docs.openalex.org/api-entities/publishers), and [Funders](https://docs.openalex.org/api-entities/funders).
 
 ```python
-from pyalex import Works, Authors, Sources, Institutions, Concepts, Publishers, Funders
+from pyalex import Works, Authors, Sources, Institutions, Concepts, Topics, Publishers, Funders
 ```
 
 ### The polite pool
@@ -65,7 +65,7 @@ pyalex.config.email = "mail@example.com"
 
 ### Get single entity
 
-Get a single Work, Author, Source, Institution, Concept, Publisher or Funder from OpenAlex by the
+Get a single Work, Author, Source, Institution, Concept, Topic, Publisher or Funder from OpenAlex by the
 OpenAlex ID, or by DOI or ROR.
 
 ```python
@@ -87,7 +87,7 @@ Works()["W2741809807"]["open_access"]
 {'is_oa': True, 'oa_status': 'gold', 'oa_url': 'https://doi.org/10.7717/peerj.4375'}
 ```
 
-The previous works also for Authors, Venues, Institutions and Concepts
+The previous works also for Authors, Venues, Institutions, Concepts and Topics
 
 ```python
 Authors()["A2887243803"]
@@ -96,7 +96,7 @@ Authors()["https://orcid.org/0000-0002-4297-0502"]  # same
 
 #### Get random
 
-Get a [random Work, Author, Source, Institution, Concept, Publisher or Funder](https://docs.openalex.org/how-to-use-the-api/get-single-entities/random-result).
+Get a [random Work, Author, Source, Institution, Concept, Topic, Publisher or Funder](https://docs.openalex.org/how-to-use-the-api/get-single-entities/random-result).
 
 ```python
 Works().random()
@@ -104,6 +104,7 @@ Authors().random()
 Sources().random()
 Institutions().random()
 Concepts().random()
+Topics().random()
 Publishers().random()
 Funders().random()
 ```
@@ -146,7 +147,7 @@ Works().count()
 For lists of entities, you can return the result as well as the metadata. By default, only the results are returned.
 
 ```python
-results, meta = Concepts().get(return_meta=True)
+results, meta = Topics().get(return_meta=True)
 ```
 
 ```python

--- a/pyalex/__init__.py
+++ b/pyalex/__init__.py
@@ -19,6 +19,12 @@ from pyalex.api import Publisher
 from pyalex.api import Publishers
 from pyalex.api import Source
 from pyalex.api import Sources
+from pyalex.api import Domain
+from pyalex.api import Domains
+from pyalex.api import Field
+from pyalex.api import Fields
+from pyalex.api import Subfield
+from pyalex.api import Subfields
 from pyalex.api import Topic
 from pyalex.api import Topics
 from pyalex.api import Venue
@@ -45,6 +51,12 @@ __all__ = [
     "Institution",
     "Concepts",
     "Concept",
+    "Domains",
+    "Domain",
+    "Fields",
+    "Field",
+    "Subfields",
+    "Subfield",
     "Topics",
     "Topic",
     "People",

--- a/pyalex/__init__.py
+++ b/pyalex/__init__.py
@@ -19,6 +19,8 @@ from pyalex.api import Publisher
 from pyalex.api import Publishers
 from pyalex.api import Source
 from pyalex.api import Sources
+from pyalex.api import Topic
+from pyalex.api import Topics
 from pyalex.api import Venue
 from pyalex.api import Venues
 from pyalex.api import Work
@@ -43,6 +45,8 @@ __all__ = [
     "Institution",
     "Concepts",
     "Concept",
+    "Topics",
+    "Topic",
     "People",
     "Journals",
     "config",

--- a/pyalex/api.py
+++ b/pyalex/api.py
@@ -405,6 +405,30 @@ class Concepts(BaseOpenAlex):
     resource_class = Concept
 
 
+class Domain(OpenAlexEntity):
+    pass
+
+
+class Domains(BaseOpenAlex):
+    resource_class = Domain
+
+
+class Field(OpenAlexEntity):
+    pass
+
+
+class Fields(BaseOpenAlex):
+    resource_class = Field
+
+
+class Subfield(OpenAlexEntity):
+    pass
+
+
+class Subfields(BaseOpenAlex):
+    resource_class = Subfield
+
+
 class Topic(OpenAlexEntity):
     pass
 

--- a/pyalex/api.py
+++ b/pyalex/api.py
@@ -405,6 +405,14 @@ class Concepts(BaseOpenAlex):
     resource_class = Concept
 
 
+class Topic(OpenAlexEntity):
+    pass
+
+
+class Topics(BaseOpenAlex):
+    resource_class = Topic
+
+
 class Publisher(OpenAlexEntity):
     pass
 

--- a/tests/test_pyalex.py
+++ b/tests/test_pyalex.py
@@ -12,7 +12,7 @@ from pyalex import Funders
 from pyalex import Institutions
 from pyalex import Publishers
 from pyalex import Sources
-from pyalex import Topics
+from pyalex import Domains, Fields, Subfields, Topics
 from pyalex import Work
 from pyalex import Works
 from pyalex.api import QueryError
@@ -36,6 +36,12 @@ def test_meta_entities():
     _, m = Institutions().get(return_meta=True)
     assert "count" in m
     _, m = Sources().get(return_meta=True)
+    assert "count" in m
+    _, m = Domains().get(return_meta=True)
+    assert "count" in m
+    _, m = Fields().get(return_meta=True)
+    assert "count" in m
+    _, m = Subfields().get(return_meta=True)
     assert "count" in m
     _, m = Topics().get(return_meta=True)
     assert "count" in m

--- a/tests/test_pyalex.py
+++ b/tests/test_pyalex.py
@@ -12,6 +12,7 @@ from pyalex import Funders
 from pyalex import Institutions
 from pyalex import Publishers
 from pyalex import Sources
+from pyalex import Topics
 from pyalex import Work
 from pyalex import Works
 from pyalex.api import QueryError
@@ -35,6 +36,8 @@ def test_meta_entities():
     _, m = Institutions().get(return_meta=True)
     assert "count" in m
     _, m = Sources().get(return_meta=True)
+    assert "count" in m
+    _, m = Topics().get(return_meta=True)
     assert "count" in m
     _, m = Works().get(return_meta=True)
     assert "count" in m


### PR DESCRIPTION
[Topics](https://docs.openalex.org/api-entities/topics) are supposed to replace [Concepts, which are being deprecated](https://docs.openalex.org/api-entities/concepts).

This pull request adds support for the [/topics endpoint](https://api.openalex.org/topics).
#34 