### PR TITLE
Ensure that filter values are URL encoded

### DIFF
--- a/pyalex/api.py
+++ b/pyalex/api.py
@@ -239,7 +239,7 @@ class BaseOpenAlex:
                 v_quote = [quote_plus(q) for q in v]
                 l_params.append(k + "=" + ",".join(v_quote))
             elif k in ["filter", "sort"]:
-                l_params.append(k + "=" + _flatten_kv(v))
+                l_params.append(k + "=" + quote_plus(_flatten_kv(v)))
             else:
                 l_params.append(k + "=" + quote_plus(str(v)))
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,3 +38,7 @@ select = ["E", "F", "UP", "I", "B"]
 
 [tool.ruff.lint.isort]
 force-single-line = true
+
+[tool.pytest.ini_options]
+pythonpath = ["."]
+addopts = "-v"

--- a/tests/test_pyalex.py
+++ b/tests/test_pyalex.py
@@ -139,7 +139,7 @@ def test_works_multifilter():
 
 
 def test_works_url():
-    url = "https://api.openalex.org/works?filter=publication_year:2020,is_oa:true"
+    url = "https://api.openalex.org/works?filter=publication_year%3A2020%2Cis_oa%3Atrue"
 
     assert url == Works().filter(publication_year=2020, is_oa=True).url
     assert url == Works().filter(publication_year=2020).filter(is_oa=True).url
@@ -258,7 +258,7 @@ def test_random_publishers():
 
 def test_and_operator():
     # https://github.com/J535D165/pyalex/issues/11
-    url = "https://api.openalex.org/works?filter=institutions.country_code:tw,institutions.country_code:hk,institutions.country_code:us,publication_year:2022"  # noqa
+    url = "https://api.openalex.org/works?filter=institutions.country_code%3Atw%2Cinstitutions.country_code%3Ahk%2Cinstitutions.country_code%3Aus%2Cpublication_year%3A2022"
 
     assert (
         url
@@ -288,12 +288,12 @@ def test_and_operator():
 
 
 def test_sample():
-    url = "https://api.openalex.org/works?filter=publication_year:2020,is_oa:true&sample=50"
+    url = "https://api.openalex.org/works?filter=publication_year%3A2020%2Cis_oa%3Atrue&sample=50"
     assert url == Works().filter(publication_year=2020, is_oa=True).sample(50).url
 
 
 def test_sample_seed():
-    url = "https://api.openalex.org/works?filter=publication_year:2020,is_oa:true&sample=50&seed=535"  # noqa
+    url = "https://api.openalex.org/works?filter=publication_year%3A2020%2Cis_oa%3Atrue&sample=50&seed=535"  # noqa
     assert (
         url
         == Works().filter(publication_year=2020, is_oa=True).sample(50, seed=535).url
@@ -328,3 +328,7 @@ def test_autocomplete():
     a = autocomplete("stockholm resilience")
 
     assert len(a) > 5
+
+
+def test_filter_urlencoding():
+    assert Works().filter(doi="10.1207/s15327809jls0703&4_2").count() == 1


### PR DESCRIPTION
There are some cases where the filter query needs to be URL encoded, such as when querying for a DOI that has an ampersand in it.

Fixes #41