### PR TITLE
Return error when paging with cursor method while using sample

### DIFF
--- a/pyalex/api.py
+++ b/pyalex/api.py
@@ -307,6 +307,8 @@ class BaseOpenAlex:
 
     def paginate(self, method="cursor", page=1, per_page=None, cursor="*", n_max=10000):
         if method == "cursor":
+            if self.params.get("sample"):
+                raise ValueError("method should be 'page' when using sample")
             value = cursor
         elif method == "page":
             value = page

--- a/tests/test_paging.py
+++ b/tests/test_paging.py
@@ -95,3 +95,8 @@ def test_cursor_paging_n_max_none():
     )
 
     sum(len(page) for page in p)
+
+
+def test_paging_with_sample():
+    p = Authors().sample(26).paginate(per_page=25)
+    assert sum(len(page) for page in p) == 26

--- a/tests/test_paging.py
+++ b/tests/test_paging.py
@@ -1,3 +1,5 @@
+import pytest
+
 import pyalex
 from pyalex import Authors
 from pyalex.api import Paginator
@@ -98,5 +100,5 @@ def test_cursor_paging_n_max_none():
 
 
 def test_paging_with_sample():
-    p = Authors().sample(26).paginate(per_page=25)
-    assert sum(len(page) for page in p) == 26
+    with pytest.raises(ValueError):
+        Authors().sample(1).paginate(method="cursor")


### PR DESCRIPTION
When sampling records from OpenAlex you must use basic paging instead of cursor paging (see [the OpenAlex docs](https://docs.openalex.org/how-to-use-the-api/get-lists-of-entities/sample-entity-lists#limitations)).

Currently pyalex has cursor paging as the default method. If you combine `sample` with `paginate` it will present the first page and then silently stop paging, without any error. For example, the following test fails:

```
def test_paging_with_sample():
    p = Authors().sample(26).paginate(per_page=25)
    assert sum(len(page) for page in p) == 26
```
Pyalex will choose the default `cursor` method, and only return the first page. So the left side of the assert statement will be 25.

In this pull request I make pyalex raise a `ValueError` when trying to use cursor pagination with sampling. If you want, I can also change it so that the default method for pagination becomes `page` in case of sampling, but I thought it was better to be explicit and just let the user know that their combination is not allowed. Let me know if you think differently and I'll update my changes!