### PR TITLE
Remove deprecationWarnings on import pyalex and remove Venues

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Works()["W2741809807"]["open_access"]
 {'is_oa': True, 'oa_status': 'gold', 'oa_url': 'https://doi.org/10.7717/peerj.4375'}
 ```
 
-The previous works also for Authors, Venues, Institutions, Concepts and Topics
+The previous works also for Authors, Sources, Institutions, Concepts and Topics
 
 ```python
 Authors()["A2887243803"]

--- a/pyalex/__init__.py
+++ b/pyalex/__init__.py
@@ -27,8 +27,6 @@ from pyalex.api import Subfield
 from pyalex.api import Subfields
 from pyalex.api import Topic
 from pyalex.api import Topics
-from pyalex.api import Venue
-from pyalex.api import Venues
 from pyalex.api import Work
 from pyalex.api import Works
 from pyalex.api import autocomplete
@@ -46,8 +44,6 @@ __all__ = [
     "Funders",
     "Publishers",
     "Publisher",
-    "Venues",
-    "Venue",
     "Institutions",
     "Institution",
     "Concepts",

--- a/pyalex/api.py
+++ b/pyalex/api.py
@@ -483,45 +483,26 @@ class autocompletes(BaseOpenAlex):
         )
 
 
-def Venue(*args, **kwargs):  # deprecated
-    # warn about deprecation
-    warnings.warn(
-        "Venue is deprecated. Use Sources instead.",
-        DeprecationWarning,
-        stacklevel=2,
-    )
-
-    return Source(*args, **kwargs)
-
-
-def Venues(*args, **kwargs):  # deprecated
-    # warn about deprecation
-    warnings.warn(
-        "Venues is deprecated. Use Sources instead.",
-        DeprecationWarning,
-        stacklevel=2,
-    )
-
-    return Sources(*args, **kwargs)
-
-
 class Concept(OpenAlexEntity):
-    # warn about deprecation
-    warnings.warn(
-        "Concept is deprecated by OpenAlex and replaced by topics.",
-        DeprecationWarning,
-        stacklevel=2,
-    )
+    def __init__(self, *args, **kwargs):
+        warnings.warn(
+            "Concept is deprecated by OpenAlex and replaced by topics.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        super().__init__(*args, **kwargs)
 
 
 class Concepts(BaseOpenAlex):
-    # warn about deprecation
-    warnings.warn(
-        "Concepts is deprecated by OpenAlex and replaced by topics.",
-        DeprecationWarning,
-        stacklevel=2,
-    )
     resource_class = Concept
+
+    def __init__(self, *args, **kwargs):
+        warnings.warn(
+            "Concepts is deprecated by OpenAlex and replaced by topics.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        super().__init__(*args, **kwargs)
 
 
 def autocomplete(s):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,4 +41,4 @@ force-single-line = true
 
 [tool.pytest.ini_options]
 pythonpath = ["."]
-addopts = "-v"
+addopts = "-v -W error"

--- a/tests/test_pyalex.py
+++ b/tests/test_pyalex.py
@@ -37,8 +37,6 @@ def test_config():
 def test_meta_entities():
     _, m = Authors().get(return_meta=True)
     assert "count" in m
-    _, m = Concepts().get(return_meta=True)
-    assert "count" in m
     _, m = Institutions().get(return_meta=True)
     assert "count" in m
     _, m = Sources().get(return_meta=True)
@@ -54,6 +52,12 @@ def test_meta_entities():
     _, m = Works().get(return_meta=True)
     assert "count" in m
     _, m = Funders().get(return_meta=True)
+    assert "count" in m
+
+
+@pytest.mark.filterwarnings("ignore:.*deprecated.*:DeprecationWarning")
+def test_meta_entities_deprecated():
+    _, m = Concepts().get(return_meta=True)
     assert "count" in m
 
 


### PR DESCRIPTION
Pyalex raised deprecation warnings for venues and concepts on import. As we don't want to bother the user who doesn't use these, we should remove the warnings from the import. For concepts, the warning is now raised on class init. Venues are entirely removed as OpenAlex seems to have dropped support completely (replaced by Sources). 