### PR TITLE
Asyncio support

### DIFF
--- a/README.md
+++ b/README.md
@@ -430,6 +430,17 @@ import pyalex
 pyalex.config.api_key = "<MY_KEY>"
 ```
 
+### Async requests
+
+To improve performance you may use concurrent requests instead of sequentials but keep in mind that OpenAlex has [rate limits](https://docs.openalex.org/how-to-use-the-api/rate-limits-and-authentication).
+
+```
+from pyalex import Works, concurrent
+worker = lambda x: Works().search_filter( **x )
+targets = [{"title": "science"}, {"title": "fiction"}]
+await concurrent(worker, targets, frequency=10)
+```
+
 ## Alternatives
 
 R users can use the excellent [OpenAlexR](https://github.com/ropensci/openalexR) library.

--- a/pyalex/__init__.py
+++ b/pyalex/__init__.py
@@ -32,6 +32,7 @@ from pyalex.api import Works
 from pyalex.api import autocomplete
 from pyalex.api import config
 from pyalex.api import invert_abstract
+from pyalex.api import concurrent
 
 __all__ = [
     "Works",
@@ -61,4 +62,5 @@ __all__ = [
     "autocomplete",
     "config",
     "invert_abstract",
+    "concurrent",
 ]

--- a/pyalex/api.py
+++ b/pyalex/api.py
@@ -310,6 +310,17 @@ class BaseOpenAlex:
         self._prepare_get(page, per_page, cursor)
         return self._get_from_url(self.url, return_meta=return_meta)
 
+    async def _get_from_url_async(self, session, url, return_meta=False):
+        async with session.get(url) as res:
+            res.raise_for_status()
+            res_json = await res.json()
+
+        return self._group_by_results_page(res_json, return_meta)
+
+    async def get_async(self, session, return_meta=False, page=None, per_page=None, cursor=None):
+        self._prepare_get(page, per_page, cursor)
+        return await self._get_from_url_async(session, self.url, return_meta=return_meta)
+
     def paginate(self, method="cursor", page=1, per_page=None, cursor="*", n_max=10000):
         if method == "cursor":
             if self.params.get("sample"):


### PR DESCRIPTION
It uses [asyncio](https://docs.python.org/3/library/asyncio.html) to speed up fetching multiple entities of the same type. Open Alex has now [rate limit 10/s](https://docs.openalex.org/how-to-use-the-api/rate-limits-and-authentication) so it may be a significant boost as up to 9 new requests don't have to wait for a previous one to be resolved

```py
from pyalex import Works, concurrent
worker = lambda x: Works().search_filter( **x )
targets = [{"title": "science"}, {"title": "fiction"}]
await concurrent(worker, targets, frequency=10)
```