### PR TITLE
Add response list-like object and deprecate return_meta

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,11 +158,11 @@ Works().count()
 For lists of entities, you can return the result as well as the metadata. By default, only the results are returned.
 
 ```python
-results, meta = Topics().get(return_meta=True)
+topics = Topics().get()
 ```
 
 ```python
-print(meta)
+print(topics.meta)
 {'count': 65073, 'db_response_time_ms': 16, 'page': 1, 'per_page': 25}
 ```
 

--- a/pyalex/__init__.py
+++ b/pyalex/__init__.py
@@ -18,6 +18,7 @@ from pyalex.api import Funders
 from pyalex.api import Institution
 from pyalex.api import Institutions
 from pyalex.api import Journals
+from pyalex.api import OpenAlexResponseList
 from pyalex.api import People
 from pyalex.api import Publisher
 from pyalex.api import Publishers
@@ -61,4 +62,5 @@ __all__ = [
     "autocomplete",
     "config",
     "invert_abstract",
+    "OpenAlexResponseList",
 ]

--- a/pyalex/api.py
+++ b/pyalex/api.py
@@ -186,11 +186,10 @@ class OpenAlexResponseList(list):
         a OpenAlexResponseList object
     """
 
-    def __init__(self, results, meta=None, resource_class=None):
+    def __init__(self, results, meta=None, resource_class=OpenAlexEntity):
         self.resource_class = resource_class
         self.meta = meta
 
-        resource_class = resource_class or OpenAlexEntity
         super().__init__([resource_class(ent) for ent in results])
 
 

--- a/pyalex/api.py
+++ b/pyalex/api.py
@@ -304,9 +304,7 @@ class BaseOpenAlex:
             raise ValueError("record_id should be a string or a list of strings")
 
     def _url_query(self):
-        if isinstance(self.params, str):
-            return _quote_oa_value(self.params)
-        elif isinstance(self.params, list):
+        if isinstance(self.params, list):
             return self.filter_or(openalex_id=self.params)
         elif isinstance(self.params, dict):
             l_params = []
@@ -330,16 +328,16 @@ class BaseOpenAlex:
 
     @property
     def url(self):
-        return urlunparse(
-            (
-                "https",
-                "api.openalex.org",
-                self.__class__.__name__.lower(),
-                "",
-                self._url_query(),
-                "",
-            )
-        )
+        base_path = self.__class__.__name__.lower()
+
+        if isinstance(self.params, str):
+            path = f"{base_path}/{_quote_oa_value(self.params)}"
+            query = ""
+        else:
+            path = base_path
+            query = self._url_query()
+
+        return urlunparse(("https", "api.openalex.org", path, "", query, ""))
 
     def count(self):
         return self.get(per_page=1).meta["count"]

--- a/pyalex/api.py
+++ b/pyalex/api.py
@@ -1,6 +1,7 @@
 import logging
 import warnings
 from urllib.parse import quote_plus
+from urllib.parse import urlunparse
 
 import requests
 from requests.auth import AuthBase
@@ -169,6 +170,30 @@ class OpenAlexEntity(dict):
     pass
 
 
+class OpenAlexResponseList(list):
+    """A list of OpenAlexEntity objects with metadata.
+
+    Attributes:
+        meta: a dictionary with metadata about the results
+        resource_class: the class to use for each entity in the results
+
+    Arguments:
+        results: a list of OpenAlexEntity objects
+        meta: a dictionary with metadata about the results
+        resource_class: the class to use for each entity in the results
+
+    Returns:
+        a OpenAlexResponseList object
+    """
+
+    def __init__(self, results, meta=None, resource_class=None):
+        self.resource_class = resource_class
+        self.meta = meta
+
+        resource_class = resource_class or OpenAlexEntity
+        super().__init__([resource_class(ent) for ent in results])
+
+
 class Paginator:
     VALUE_CURSOR_START = "*"
     VALUE_NUMBER_START = 1
@@ -205,22 +230,20 @@ class Paginator:
         else:
             raise ValueError()
 
-        results, meta = self.endpoint_class.get(
-            return_meta=True, per_page=self.per_page, **pagination_params
-        )
+        r = self.endpoint_class.get(per_page=self.per_page, **pagination_params)
 
         if self.method == "cursor":
-            self._next_value = meta["next_cursor"]
+            self._next_value = r.meta["next_cursor"]
 
         if self.method == "page":
-            if len(results) > 0:
-                self._next_value = meta["page"] + 1
+            if len(r) > 0:
+                self._next_value = r.meta["page"] + 1
             else:
                 self._next_value = None
 
-        self.n = self.n + len(results)
+        self.n = self.n + len(r)
 
-        return results
+        return r
 
 
 class OpenAlexAuth(AuthBase):
@@ -255,14 +278,6 @@ class BaseOpenAlex:
     def __init__(self, params=None):
         self.params = params
 
-    def _full_collection_name(self):
-        if self.params is not None and "q" in self.params.keys():
-            return (
-                f"{config.openalex_url}/autocomplete/{self.__class__.__name__.lower()}"
-            )
-        else:
-            return f"{config.openalex_url}/{self.__class__.__name__.lower()}"
-
     def __getattr__(self, key):
         if key == "groupby":
             raise AttributeError(
@@ -283,42 +298,56 @@ class BaseOpenAlex:
                 raise ValueError("OpenAlex does not support more than 100 ids")
 
             return self.filter_or(openalex_id=record_id).get(per_page=len(record_id))
+        elif isinstance(record_id, str):
+            self.params = record_id
+            return self._get_from_url(self.url)
+        else:
+            raise ValueError("record_id should be a string or a list of strings")
 
-        return self._get_from_url(
-            f"{self._full_collection_name()}/{_quote_oa_value(record_id)}",
-            return_meta=False,
-        )
+    def _url_query(self):
+        if isinstance(self.params, str):
+            return _quote_oa_value(self.params)
+        elif isinstance(self.params, list):
+            return self.filter_or(openalex_id=self.params)
+        elif isinstance(self.params, dict):
+            l_params = []
+            for k, v in self.params.items():
+                if v is None:
+                    pass
+                elif isinstance(v, list):
+                    l_params.append(
+                        "{}={}".format(k, ",".join(map(_quote_oa_value, v)))
+                    )
+                elif k in ["filter", "sort"]:
+                    l_params.append(f"{k}={_flatten_kv(v)}")
+                else:
+                    l_params.append(f"{k}={_quote_oa_value(v)}")
+
+            if l_params:
+                return "&".join(l_params)
+
+        else:
+            return ""
 
     @property
     def url(self):
-        if not self.params:
-            return self._full_collection_name()
-
-        l_params = []
-        for k, v in self.params.items():
-            if v is None:
-                pass
-            elif isinstance(v, list):
-                l_params.append("{}={}".format(k, ",".join(map(_quote_oa_value, v))))
-            elif k in ["filter", "sort"]:
-                l_params.append(f"{k}={_flatten_kv(v)}")
-            else:
-                l_params.append(f"{k}={_quote_oa_value(v)}")
-
-        if l_params:
-            return "{}?{}".format(self._full_collection_name(), "&".join(l_params))
-
-        return self._full_collection_name()
+        return urlunparse(
+            (
+                "https",
+                "api.openalex.org",
+                self.__class__.__name__.lower(),
+                "",
+                self._url_query(),
+                "",
+            )
+        )
 
     def count(self):
-        _, m = self.get(return_meta=True, per_page=1)
+        return self.get(per_page=1).meta["count"]
 
-        return m["count"]
-
-    def _get_from_url(self, url, return_meta=False):
+    def _get_from_url(self, url):
         res = _get_requests_session().get(url, auth=OpenAlexAuth(config))
 
-        # handle query errors
         if res.status_code == 403:
             if (
                 isinstance(res.json()["error"], str)
@@ -329,30 +358,39 @@ class BaseOpenAlex:
         res.raise_for_status()
         res_json = res.json()
 
-        # group-by or results page
         if self.params and "group-by" in self.params:
-            results = res_json["group_by"]
+            return OpenAlexResponseList(
+                res_json["group_by"], res_json["meta"], self.resource_class
+            )
         elif "results" in res_json:
-            results = [self.resource_class(ent) for ent in res_json["results"]]
+            return OpenAlexResponseList(
+                res_json["results"], res_json["meta"], self.resource_class
+            )
         elif "id" in res_json:
-            results = self.resource_class(res_json)
+            return self.resource_class(res_json)
         else:
             raise ValueError("Unknown response format")
-
-        # return result and metadata
-        if return_meta:
-            return results, res_json["meta"]
-        else:
-            return results
 
     def get(self, return_meta=False, page=None, per_page=None, cursor=None):
         if per_page is not None and (per_page < 1 or per_page > 200):
             raise ValueError("per_page should be a number between 1 and 200.")
 
-        self._add_params("per-page", per_page)
-        self._add_params("page", page)
-        self._add_params("cursor", cursor)
-        return self._get_from_url(self.url, return_meta=return_meta)
+        if not isinstance(self.params, (str, list)):
+            self._add_params("per-page", per_page)
+            self._add_params("page", page)
+            self._add_params("cursor", cursor)
+
+        resp_list = self._get_from_url(self.url)
+
+        if return_meta:
+            warnings.warn(
+                "return_meta is deprecated, call .meta on the result",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            return resp_list, resp_list.meta
+        else:
+            return resp_list
 
     def paginate(self, method="cursor", page=1, per_page=None, cursor="*", n_max=10000):
         if method == "cursor":
@@ -432,10 +470,32 @@ class BaseOpenAlex:
         self._add_params("select", s)
         return self
 
-    def autocomplete(self, s, **kwargs):
+    def autocomplete(self, s, return_meta=False):
         """autocomplete the string s, for a specific type of entity"""
         self._add_params("q", s)
-        return self.get(**kwargs)
+
+        resp_list = self._get_from_url(
+            urlunparse(
+                (
+                    "https",
+                    "api.openalex.org",
+                    f"autocomplete/{self.__class__.__name__.lower()}",
+                    "",
+                    self._url_query(),
+                    "",
+                )
+            )
+        )
+
+        if return_meta:
+            warnings.warn(
+                "return_meta is deprecated, call .meta on the result",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            return resp_list, resp_list.meta
+        else:
+            return resp_list
 
 
 # The API
@@ -456,11 +516,17 @@ class Work(OpenAlexEntity):
         res.raise_for_status()
         results = res.json()
 
-        # return result and metadata
+        resp_list = OpenAlexResponseList(results["ngrams"], results["meta"])
+
         if return_meta:
-            return results["ngrams"], results["meta"]
+            warnings.warn(
+                "return_meta is deprecated, call .meta on the result",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            return resp_list, resp_list.meta
         else:
-            return results["ngrams"]
+            return resp_list
 
 
 class Works(BaseOpenAlex):
@@ -550,7 +616,16 @@ class autocompletes(BaseOpenAlex):
 
     def __getitem__(self, key):
         return self._get_from_url(
-            f"{config.openalex_url}/autocomplete?q={key}", return_meta=False
+            urlunparse(
+                (
+                    "https",
+                    "api.openalex.org",
+                    "autocomplete",
+                    "",
+                    f"q={quote_plus(key)}",
+                    "",
+                )
+            )
         )
 
 

--- a/tests/test_paging.py
+++ b/tests/test_paging.py
@@ -18,13 +18,13 @@ def test_cursor():
     # loop till next_cursor is None
     while next_cursor is not None:
         # get the results
-        r, m = query.get(return_meta=True, per_page=200, cursor=next_cursor)
+        r = query.get(per_page=200, cursor=next_cursor)
 
         # results
         results.extend(r)
 
         # set the next cursor
-        next_cursor = m["next_cursor"]
+        next_cursor = r.meta["next_cursor"]
 
     assert len(results) > 200
 
@@ -41,17 +41,17 @@ def test_page():
     # loop till page is None
     while page is not None:
         # get the results
-        r, m = query.get(return_meta=True, per_page=200, page=page)
+        r = query.get(per_page=200, page=page)
 
         # results
         results.extend(r)
-        page = None if len(r) == 0 else m["page"] + 1
+        page = None if len(r) == 0 else r.meta["page"] + 1
 
     assert len(results) > 200
 
 
 def test_paginate_counts():
-    _, m = Authors().search_filter(display_name="einstein").get(return_meta=True)
+    r = Authors().search_filter(display_name="einstein").get()
 
     p_default = Authors().search_filter(display_name="einstein").paginate(per_page=200)
     n_p_default = sum(len(page) for page in p_default)
@@ -70,7 +70,7 @@ def test_paginate_counts():
     )
     n_p_page = sum(len(page) for page in p_page)
 
-    assert m["count"] == n_p_page >= n_p_default == n_p_cursor
+    assert r.meta["count"] == n_p_page >= n_p_default == n_p_cursor
 
 
 def test_paginate_instance():


### PR DESCRIPTION
This PR proposes deprecating the `return_meta` argument and introducing `OpenAlexResponseList`, which inherits from a list. Technically, this is a breaking change, but it most likely won't affect the library users in my opinion. 

Example of the old code:

```python
w, meta = Works().get(return_meta=True)
```

With the new syntax, you receive a `OpenAlexResponseList` object with a `meta` attribute:
```python
w = Works().get()
```

```python
w.meta
```

The new syntax simplifies our code base and avoids confusing syntax for our users. 

Note: The old syntax will still work but will raise a deprecation warning. 