### PR TITLE
Added method to download a list of OpenAlex entities

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ classifiers = [
     "Programming Language :: Python :: 3.12"
 ]
 license = {text = "MIT"}
-dependencies = ["requests", "urllib3"]
+dependencies = ["requests", "urllib3", "tqdm"]
 dynamic = ["version"]
 requires-python = ">=3.8"
 

--- a/tests/test_pyalex.py
+++ b/tests/test_pyalex.py
@@ -425,3 +425,20 @@ def test_urlencoding_list():
         .count()
         == 2
     )
+
+
+def test_get_from_ids():
+    # test with a list of 3 articles
+    entities_ids = [
+        "W4409154704",
+        "W1999167944",
+        "W2096885696",
+    ]
+    entities_names = [
+        "Challenges and opportunities when assessing exposure of financial investments to ecosystem regime shifts",
+        "Planetary boundaries: Guiding human development on a changing planet",
+        "A safe operating space for humanity",
+    ]
+    res = pyalex.Works().get_from_ids(entities_ids)
+    for i in range(len(entities_names)):
+        assert entities_names[i] == res[i]["display_name"]


### PR DESCRIPTION
I added a method to download a list of OpenAlex entities from a list of IDs. It's getting the IDs 100 per 100, returning Nones when the entities are not found and optionally ordering the list of entities according to the IDs list.

It's a draft as the documentation is not yet added as I would like feedbacks on this implementation. If it's alright, I'll also add a method to get a list of Works from the DOI (I will have a look if it's possible for other entities e.g. with ROR for institutions). I'm using `tqdm` for the loading bar with an option in the config to disable it, this can be changed too.

As a side note, the tests are failing due to a bug of OpenAlex that I already had: the count of works are different with `["meta"]["count"]` and `.count()`.