### PR TITLE
Add OpenAlex Premium authentication test

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -16,6 +16,8 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
+    - name: Set OPENALEX_API_KEY from secret
+      run: echo "OPENALEX_API_KEY=${{ secrets.OPENALEX_API_KEY }}" >> $GITHUB_ENV
     - name: Install package and dependencies
       run: |
         python -m pip install --upgrade pip

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ requires-python = ">=3.8"
 
 [project.optional-dependencies]
 lint = ["ruff"]
-test = ["pytest", "pytest-xdist"]
+test = ["pytest", "pytest-xdist", "dotenv"]
 
 [build-system]
 build-backend = 'setuptools.build_meta'

--- a/tests/test_pyalex.py
+++ b/tests/test_pyalex.py
@@ -1,8 +1,11 @@
+import datetime
 import json
+import os
 from pathlib import Path
 
 import pytest
 import requests
+from dotenv import load_dotenv
 from requests import HTTPError
 
 import pyalex
@@ -20,6 +23,9 @@ from pyalex import Work
 from pyalex import Works
 from pyalex import autocomplete
 from pyalex.api import QueryError
+
+# Load environment variables from .env file
+load_dotenv()
 
 pyalex.config.max_retries = 10
 
@@ -425,3 +431,14 @@ def test_urlencoding_list():
         .count()
         == 2
     )
+
+
+@pytest.mark.skipif(
+    not os.environ.get("OPENALEX_API_KEY"),
+    reason="OPENALEX_API_KEY is not set in the environment variables",
+)
+def test_premium_api():
+    # This test requires a valid API key and email set in the config.
+    pyalex.config.api_key = os.environ["OPENALEX_API_KEY"]
+
+    Works().filter(from_updated_date=f"{datetime.datetime.now().year}-01-01").get()

--- a/tests/test_pyalex.py
+++ b/tests/test_pyalex.py
@@ -386,19 +386,6 @@ def test_subset():
     assert url == Works().select(["id", "doi", "display_name"]).url
 
 
-def test_auth():
-    w_no_auth = Works().get()
-    pyalex.config.email = "pyalex_github_unittests@example.com"
-    pyalex.config.api_key = "my_api_key"
-
-    w_auth = Works().get()
-
-    pyalex.config.email = None
-    pyalex.config.api_key = None
-
-    assert len(w_no_auth) == len(w_auth)
-
-
 def test_autocomplete_works():
     w = Works().filter(publication_year=2023).autocomplete("planetary boundaries")
 
@@ -433,12 +420,31 @@ def test_urlencoding_list():
     )
 
 
+def test_premium_api_no_valid_key():
+    # This test checks if the API works without a valid API key.
+    # It should return the same results as with a valid key.
+    w_no_auth = Works().get()
+    pyalex.config.email = "pyalex_github_unittests@example.com"
+    pyalex.config.api_key = "my_api_key"
+
+    w_auth = Works().get()
+
+    pyalex.config.email = None
+    pyalex.config.api_key = None
+
+    assert len(w_no_auth) == len(w_auth)
+
+
 @pytest.mark.skipif(
     not os.environ.get("OPENALEX_API_KEY"),
     reason="OPENALEX_API_KEY is not set in the environment variables",
 )
 def test_premium_api():
-    # This test requires a valid API key and email set in the config.
+    # This test requires a valid API key set in the config. If from_updated_date
+    # is set, it should return works updated since the start of the current
+    # year. If no API key is set, it should raise an error.
     pyalex.config.api_key = os.environ["OPENALEX_API_KEY"]
 
     Works().filter(from_updated_date=f"{datetime.datetime.now().year}-01-01").get()
+
+    pyalex.config.api_key = None


### PR DESCRIPTION
The OpenAlex team provided us with an API key for testing purposes. Thanks to the team. 

All functionality works fine!

For local testing purposes, you can either add the' OPENALEX_API_KEY' environment variable or create a `.env` file with the variable. 