### PR TITLE
Give the logger the name `pyalex`

### DIFF
--- a/pyalex/api.py
+++ b/pyalex/api.py
@@ -14,6 +14,7 @@ except ImportError:
 
 logger = logging.getLogger("pyalex")
 
+
 class AlexConfig(dict):
     """Configuration class for OpenAlex API.
 


### PR DESCRIPTION
THis is needed to correctly filter PyAlex log in the downstream application