### PR TITLE
Add rate-limit and credit headers to response meta

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,8 +84,10 @@ The OpenAlex API uses a credit-based rate limiting system. Different endpoint ty
 
 - **Without API key**: 100 credits per day (testing/demos only)
 - **With free API key**: 100,000 credits per day
-- **Singleton requests** (e.g., `/works/W123`): Free (0 credits)
-- **List requests** (e.g., `/works?filter=...`): 1 credit each
+- **Singleton by OpenAlex ID** (e.g., `/works/W123`): Free (0 credits)
+- **Singleton by external ID** (e.g., DOI, ORCID, ROR): 1 credit
+- **List/filter requests** (e.g., `/works?filter=...`): 1 credit each
+- **Search requests** (e.g., `/works?search=...`): 10 credits each
 
 All users are limited to a maximum of 100 requests per second.
 
@@ -103,6 +105,41 @@ pyalex.config.api_key = "<YOUR_API_KEY>"
 
 For more information, see the [OpenAlex Rate limits and authentication documentation](https://docs.openalex.org/how-to-use-the-api/rate-limits-and-authentication).
 
+#### Monitor usage
+
+Every API response includes rate-limit and credit information in `meta["ratelimit"]`. This works for both list results and singleton lookups:
+
+```python
+from pyalex import Works
+
+# List results
+results = Works().filter(publication_year=2020).get()
+print(results.meta["ratelimit"])
+# {'credits_used': 1, 'credits_remaining': 9999, 'cost_usd': 0.0001, ...}
+
+# Singleton results
+work = Works()["W2741809807"]
+print(work.meta["ratelimit"])
+# {'credits_used': 0, 'credits_remaining': 9999, ...}
+```
+
+Available fields in `meta["ratelimit"]`:
+
+| Key | Type | Description |
+|---|---|---|
+| `credits_used` | int | Credits consumed by this request |
+| `credits_required` | int | Credits required for this request type |
+| `credits_limit` | int | Total daily credit allowance |
+| `credits_remaining` | int | Credits remaining today |
+| `onetime_remaining` | int | One-time bonus credits remaining |
+| `reset_seconds` | int | Seconds until daily credits reset |
+| `cost_usd` | float | USD cost of this request |
+| `cost_required_usd` | float | USD cost required for this request type |
+| `limit_usd` | float | Total daily USD allowance |
+| `remaining_usd` | float | USD remaining today |
+| `prepaid_remaining_usd` | float | Prepaid USD balance remaining |
+
+Fields are omitted from the dict if the corresponding header is absent from the response.
 
 ### Get single entity
 
@@ -116,7 +153,7 @@ Works()["W2741809807"]
 Works()["https://doi.org/10.7717/peerj.4375"]
 ```
 
-The result is a `Work` object, which is very similar to a dictionary. Find the available fields with `.keys()`.
+The result is a `Work` object, which is very similar to a dictionary. Find the available fields with `.keys()`. Singleton results also have a `.meta` attribute containing rate-limit information (see [Monitor usage](#monitor-usage)).
 
 For example, get the open access status:
 
@@ -243,8 +280,10 @@ topics = Topics().get()
 
 ```python
 print(topics.meta)
-{'count': 65073, 'db_response_time_ms': 16, 'page': 1, 'per_page': 25}
+{'count': 65073, 'db_response_time_ms': 16, 'page': 1, 'per_page': 25, 'groups_count': None, 'cost_usd': 0.0001, 'ratelimit': {'credits_used': 1, 'credits_remaining': 9999, ...}}
 ```
+
+The `ratelimit` key contains per-request credit and cost information extracted from the response headers. See [Monitor usage](#monitor-usage) for details.
 
 #### Filter records
 

--- a/pyalex/api.py
+++ b/pyalex/api.py
@@ -226,6 +226,50 @@ def _get_requests_session():
     return requests_session
 
 
+_RATELIMIT_INT_HEADERS = {
+    "credits_used": "X-RateLimit-Credits-Used",
+    "credits_required": "X-RateLimit-Credits-Required",
+    "credits_limit": "X-RateLimit-Limit",
+    "credits_remaining": "X-RateLimit-Remaining",
+    "onetime_remaining": "X-RateLimit-Onetime-Remaining",
+    "reset_seconds": "X-RateLimit-Reset",
+}
+
+_RATELIMIT_FLOAT_HEADERS = {
+    "cost_usd": "X-RateLimit-Cost-USD",
+    "cost_required_usd": "X-RateLimit-Cost-Required-USD",
+    "limit_usd": "X-RateLimit-Limit-USD",
+    "remaining_usd": "X-RateLimit-Remaining-USD",
+    "prepaid_remaining_usd": "X-RateLimit-Prepaid-Remaining-USD",
+}
+
+
+def _extract_ratelimit(res):
+    """Extract rate-limit and credit info from response headers.
+
+    Parameters
+    ----------
+    res : requests.Response
+        HTTP response from the OpenAlex API.
+
+    Returns
+    -------
+    dict
+        Rate-limit information. Keys are omitted if the
+        corresponding header is absent.
+    """
+    ratelimit = {}
+    for key, header in _RATELIMIT_INT_HEADERS.items():
+        value = res.headers.get(header)
+        if value is not None:
+            ratelimit[key] = int(value)
+    for key, header in _RATELIMIT_FLOAT_HEADERS.items():
+        value = res.headers.get(header)
+        if value is not None:
+            ratelimit[key] = float(value)
+    return ratelimit
+
+
 def invert_abstract(inv_index):
     """Invert OpenAlex abstract index.
 
@@ -539,17 +583,22 @@ class BaseOpenAlex:
 
         res.raise_for_status()
         res_json = res.json()
+        ratelimit = _extract_ratelimit(res)
 
         if self.params and "group-by" in self.params:
+            meta = {**res_json["meta"], "ratelimit": ratelimit}
             return OpenAlexResponseList(
-                res_json["group_by"], res_json["meta"], self.resource_class
+                res_json["group_by"], meta, self.resource_class
             )
         elif "results" in res_json:
+            meta = {**res_json["meta"], "ratelimit": ratelimit}
             return OpenAlexResponseList(
-                res_json["results"], res_json["meta"], self.resource_class
+                res_json["results"], meta, self.resource_class
             )
         elif "id" in res_json:
-            return self.resource_class(res_json)
+            result = self.resource_class(res_json)
+            result.meta = {"ratelimit": ratelimit}
+            return result
         else:
             raise ValueError("Unknown response format")
 

--- a/pyalex/api.py
+++ b/pyalex/api.py
@@ -587,14 +587,10 @@ class BaseOpenAlex:
 
         if self.params and "group-by" in self.params:
             meta = {**res_json["meta"], "ratelimit": ratelimit}
-            return OpenAlexResponseList(
-                res_json["group_by"], meta, self.resource_class
-            )
+            return OpenAlexResponseList(res_json["group_by"], meta, self.resource_class)
         elif "results" in res_json:
             meta = {**res_json["meta"], "ratelimit": ratelimit}
-            return OpenAlexResponseList(
-                res_json["results"], meta, self.resource_class
-            )
+            return OpenAlexResponseList(res_json["results"], meta, self.resource_class)
         elif "id" in res_json:
             result = self.resource_class(res_json)
             result.meta = {"ratelimit": ratelimit}

--- a/tests/test_ratelimit.py
+++ b/tests/test_ratelimit.py
@@ -1,0 +1,106 @@
+import os
+from functools import wraps
+from unittest.mock import MagicMock
+
+import pytest
+
+import pyalex
+from pyalex import Works
+from pyalex.api import _extract_ratelimit
+
+pyalex.config.max_retries = 10
+
+
+def requires_api_key(reason="OpenAlex requires authentication for this operation"):
+    """Decorator for API Key requirement.
+
+    Decorator that skips test if OPENALEX_API_KEY is not set, and
+    sets it for the test.
+    """
+
+    def decorator(func):
+        @pytest.mark.skipif(
+            not os.environ.get("OPENALEX_API_KEY"),
+            reason=reason,
+        )
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            api_key = os.environ.get("OPENALEX_API_KEY")
+            original_api_key = pyalex.config.api_key
+            try:
+                pyalex.config.api_key = api_key
+                return func(*args, **kwargs)
+            finally:
+                pyalex.config.api_key = original_api_key
+
+        return wrapper
+
+    return decorator
+
+
+def test_extract_ratelimit():
+    """_extract_ratelimit parses headers to correct types."""
+    res = MagicMock()
+    res.headers = {
+        "X-RateLimit-Credits-Used": "1",
+        "X-RateLimit-Limit": "10000",
+        "X-RateLimit-Remaining": "9999",
+        "X-RateLimit-Reset": "3600",
+        "X-RateLimit-Cost-USD": "0.0001",
+        "X-RateLimit-Limit-USD": "1.0",
+        "X-RateLimit-Remaining-USD": "0.9999",
+    }
+
+    rl = _extract_ratelimit(res)
+
+    # int fields
+    assert rl["credits_used"] == 1
+    assert isinstance(rl["credits_used"], int)
+    assert rl["credits_limit"] == 10000
+    assert rl["credits_remaining"] == 9999
+    assert rl["reset_seconds"] == 3600
+
+    # float fields
+    assert rl["cost_usd"] == pytest.approx(0.0001)
+    assert isinstance(rl["cost_usd"], float)
+    assert rl["limit_usd"] == 1.0
+    assert rl["remaining_usd"] == pytest.approx(0.9999)
+
+    # absent headers are omitted
+    assert "credits_required" not in rl
+    assert "onetime_remaining" not in rl
+    assert "cost_required_usd" not in rl
+    assert "prepaid_remaining_usd" not in rl
+
+
+def test_extract_ratelimit_empty():
+    """_extract_ratelimit returns empty dict when no headers present."""
+    res = MagicMock()
+    res.headers = {}
+    assert _extract_ratelimit(res) == {}
+
+
+@requires_api_key(reason="OpenAlex requires authentication for ratelimit headers")
+def test_ratelimit_in_list_meta():
+    """List results include ratelimit in meta."""
+    r = Works().filter(publication_year=2020).get(per_page=1)
+
+    assert "ratelimit" in r.meta
+    rl = r.meta["ratelimit"]
+    assert "credits_used" in rl
+    assert "credits_remaining" in rl
+    assert isinstance(rl["credits_used"], int)
+    assert isinstance(rl["credits_remaining"], int)
+
+
+@requires_api_key(reason="OpenAlex requires authentication for ratelimit headers")
+def test_ratelimit_in_singleton_meta():
+    """Singleton results include ratelimit in meta."""
+    w = Works()["W2741809807"]
+
+    assert hasattr(w, "meta")
+    assert "ratelimit" in w.meta
+    rl = w.meta["ratelimit"]
+    assert "credits_remaining" in rl
+    # Native OpenAlex ID lookup is free
+    assert rl["credits_used"] == 0


### PR DESCRIPTION
## Summary

- Extract 11 `X-RateLimit-*` HTTP response headers from every OpenAlex API call and surface them as `meta["ratelimit"]` on both list results and singleton entity dicts
- Headers are parsed to native types: `int` for credit counts/limits, `float` for USD amounts; missing headers are omitted rather than defaulted
- Update README with "Monitor usage" section, corrected credit costs, and new OpenAlex body meta fields

## Motivation

OpenAlex's credit system (daily limits, per-request costs, prepaid balances) is returned via HTTP headers on every response, but pyalex discards them. Users who need to monitor usage or stay within budget have no way to access this information through the library.

## Details

New fields available in `meta["ratelimit"]`:

| Key | Type | Header |
|---|---|---|
| `credits_used` | int | `X-RateLimit-Credits-Used` |
| `credits_required` | int | `X-RateLimit-Credits-Required` |
| `credits_limit` | int | `X-RateLimit-Limit` |
| `credits_remaining` | int | `X-RateLimit-Remaining` |
| `onetime_remaining` | int | `X-RateLimit-Onetime-Remaining` |
| `reset_seconds` | int | `X-RateLimit-Reset` |
| `cost_usd` | float | `X-RateLimit-Cost-USD` |
| `cost_required_usd` | float | `X-RateLimit-Cost-Required-USD` |
| `limit_usd` | float | `X-RateLimit-Limit-USD` |
| `remaining_usd` | float | `X-RateLimit-Remaining-USD` |
| `prepaid_remaining_usd` | float | `X-RateLimit-Prepaid-Remaining-USD` |

### Usage

```python
import pyalex
from pyalex import Works

pyalex.config.api_key = "your-key"

# List results
results = Works().filter(publication_year=2020).get()
print(results.meta["ratelimit"])
# {'credits_used': 1, 'credits_remaining': 9999, 'cost_usd': 0.0001, ...}

# Singleton results
work = Works()["W2741809807"]
print(work.meta["ratelimit"])
# {'credits_used': 0, 'credits_remaining': 9999, ...}
```

### Scope

This patch modifies `_get_from_url` only. The `ngrams()` method and `BaseContent.get()` use separate request paths and are not covered — these could be addressed in a follow-up.

### README updates

- Added "Monitor usage" subsection with usage examples and full field reference table
- Updated meta example to reflect new OpenAlex body fields (`groups_count`, `cost_usd`)
- Corrected credit cost table: DOI/ORCID/ROR lookups cost 1 credit (not free), search requests cost 10 credits (not 1)

## Test plan

- [x] Unit tests for `_extract_ratelimit` (type coercion, missing headers, empty headers)
- [x] Live integration test: list results have `meta["ratelimit"]` with expected keys and types
- [x] Live integration test: singleton results have `.meta["ratelimit"]`, native ID lookup costs 0 credits
- [x] Full existing test suite passes (74 passed, 3 skipped, 1 pre-existing rate-limit failure)