### PR TITLE
Unescape HTML entities in invert_abstract

### DIFF
--- a/pyalex/api.py
+++ b/pyalex/api.py
@@ -2,6 +2,7 @@ import logging
 import warnings
 from urllib.parse import quote_plus
 from urllib.parse import urlunparse
+import html
 
 import requests
 from requests.auth import AuthBase
@@ -241,7 +242,7 @@ def invert_abstract(inv_index):
     """
     if inv_index is not None:
         l_inv = [(w, p) for w, pos in inv_index.items() for p in pos]
-        return " ".join(map(lambda x: x[0], sorted(l_inv, key=lambda x: x[1])))
+        return html.unescape(" ".join(map(lambda x: x[0], sorted(l_inv, key=lambda x: x[1]))))
 
 
 def _wrap_values_nested_dict(d, func):

--- a/pyalex/api.py
+++ b/pyalex/api.py
@@ -1,8 +1,8 @@
+import html
 import logging
 import warnings
 from urllib.parse import quote_plus
 from urllib.parse import urlunparse
-import html
 
 import requests
 from requests.auth import AuthBase
@@ -242,7 +242,9 @@ def invert_abstract(inv_index):
     """
     if inv_index is not None:
         l_inv = [(w, p) for w, pos in inv_index.items() for p in pos]
-        return html.unescape(" ".join(map(lambda x: x[0], sorted(l_inv, key=lambda x: x[1]))))
+        return html.unescape(
+            " ".join(map(lambda x: x[0], sorted(l_inv, key=lambda x: x[1])))
+        )
 
 
 def _wrap_values_nested_dict(d, func):


### PR DESCRIPTION
Thanks for the great package. 

The OpenAlex API sometimes returns HTML entities in abstract inverted index keys. For instance, "&" can render as "&amp". Currently, the `invert_abstract` function returns these as-is, which means that the reconstructed abstract contains the "raw" HTML entities instead of plain text. 

This PR suggests wrapping the output with `html.unescape()` to decode HTML content and improve the readability of the inverted abstracts. 

Happy to make adjustments/changes if need be. No pressure to merge if you prefer not to. 