### PR TITLE
Add configurable request timeout to all API calls

### DIFF
--- a/pyalex/api.py
+++ b/pyalex/api.py
@@ -34,6 +34,12 @@ class AlexConfig(dict):
         Backoff factor for retries.
     retry_http_codes : list
         List of HTTP status codes to retry on.
+    timeout : float or tuple or None
+        Timeout in seconds passed to every request (a (connect, read)
+        tuple is also accepted). Without it a stalled connection can
+        hang forever; with it the request raises requests.exceptions.Timeout
+        instead, and connect/read errors are retried up to max_retries
+        before the exception propagates. None disables the timeout.
     """
 
     def __getattr__(self, key):
@@ -51,6 +57,7 @@ config = AlexConfig(
     max_retries=0,
     retry_backoff_factor=0.1,
     retry_http_codes=[429, 500, 503],
+    timeout=60.0,
 )
 
 
@@ -524,7 +531,7 @@ class BaseOpenAlex:
 
         logger.debug(f"GET request to URL: {url}")
 
-        res = session.get(url, auth=OpenAlexAuth(config))
+        res = session.get(url, auth=OpenAlexAuth(config), timeout=config.timeout)
 
         if res.status_code == 400:
             if (
@@ -911,7 +918,10 @@ class BaseContent:
         content_url = f"https://content.openalex.org/works/{self.key}"
 
         res = _get_requests_session().get(
-            content_url, auth=OpenAlexAuth(config), allow_redirects=True
+            content_url,
+            auth=OpenAlexAuth(config),
+            allow_redirects=True,
+            timeout=config.timeout,
         )
         res.raise_for_status()
         return res.content
@@ -987,7 +997,9 @@ class Work(OpenAlexEntity):
         openalex_id = self["id"].split("/")[-1]
         n_gram_url = f"{config.openalex_url}/works/{openalex_id}/ngrams"
 
-        res = _get_requests_session().get(n_gram_url, auth=OpenAlexAuth(config))
+        res = _get_requests_session().get(
+            n_gram_url, auth=OpenAlexAuth(config), timeout=config.timeout
+        )
         res.raise_for_status()
         results = res.json()
 

--- a/tests/test_pyalex.py
+++ b/tests/test_pyalex.py
@@ -86,6 +86,19 @@ def test_config():
     pyalex.config.api_key = None
 
 
+def test_config_timeout():
+    assert pyalex.config.timeout == 60.0
+
+    # a (practically) zero timeout raises instead of hanging
+    original = pyalex.config.timeout
+    pyalex.config.timeout = 1e-4
+    try:
+        with pytest.raises(requests.exceptions.RequestException):
+            Works()["W4238809453"]
+    finally:
+        pyalex.config.timeout = original
+
+
 @requires_api_key(reason="OpenAlex requires authentication for unfiltered queries")
 @pytest.mark.parametrize("entity", OPEN_ALEX_ENTITIES)
 def test_meta_entities(entity):


### PR DESCRIPTION
## Problem

All HTTP requests are issued without a `timeout`, so a silently stalled connection hangs the calling thread forever — no exception is raised, which also means the `Retry` policy never gets a chance to act. This bit me while running many-hour author-matching jobs against the API from worker threads: a single stalled socket froze a worker indefinitely.

## Change

- Add a `timeout` field to `AlexConfig` (documented in the class docstring):
  - default **60 s**, generous enough that no healthy request should ever hit it;
  - a `(connect, read)` tuple is accepted (passed through to Requests);
  - `None` restores the previous unbounded behavior.
- Pass `timeout=config.timeout` at every request site: entity queries (`_get_from_url`), content downloads (`BaseContent.get`), and `Work.ngrams`.
- No retry changes needed: the existing `Retry(total=max_retries, allowed_methods={"GET", "POST"})` already counts connect/read errors — it just never triggered because no timeout could fire. With this change a timed-out request is retried with backoff like a 429, and only after `max_retries` does the exception propagate.

## Notes

- Default of 60 s is a (mild) behavior change: code that today hangs forever will raise `requests.exceptions.Timeout` after retries instead. If you prefer strict backward compatibility, changing the default to `None` makes it purely opt-in — happy to amend.
- Added `test_config_timeout`: asserts the default and that a practically-zero timeout raises `RequestException` instead of hanging (fires client-side, needs no API key).

🤖 Generated with [Claude Code](https://claude.com/claude-code)