### PR TITLE
Fix BaseContent.get() ignoring the url property of subclasses

### DIFF
--- a/pyalex/api.py
+++ b/pyalex/api.py
@@ -908,10 +908,8 @@ class BaseContent:
         bytes
             Content of the request.
         """
-        content_url = f"https://content.openalex.org/works/{self.key}"
-
         res = _get_requests_session().get(
-            content_url, auth=OpenAlexAuth(config), allow_redirects=True
+            self.url, auth=OpenAlexAuth(config), allow_redirects=True
         )
         res.raise_for_status()
         return res.content


### PR DESCRIPTION
## Problem

`BaseContent.get()` rebuilds the plain content URL from `self.key` instead of using the `url` property:

```python
content_url = f"https://content.openalex.org/works/{self.key}"
```

But `PDF` and `TEI` exist precisely to override `url` with the `.pdf` / `.grobid-xml` variants — so `work.pdf.get()` and `work.tei.get()` (and their `download()`) silently fetch the generic work content instead of the format they advertise.

The existing `test_work_pdf_and_tei_download` doesn't catch this because it only asserts the downloaded files are non-empty, which the plain URL satisfies too.

## Change

One line: `get()` now requests `self.url`, so each subclass downloads what its URL points at. Verified that `BaseContent/PDF/TEI.get()` now request `…/works/W1`, `…/works/W1.pdf` and `…/works/W1.grobid-xml` respectively.

🤖 Generated with [Claude Code](https://claude.com/claude-code)