### PR TITLE
Fail fast when Retry-After exceeds a sane bound

### DIFF
--- a/pyalex/api.py
+++ b/pyalex/api.py
@@ -203,6 +203,39 @@ def _params_merge(params, add_params):
             params[k] = add_params[k]
 
 
+class RateLimitError(Exception):
+    """Raised when the server demands a longer wait than we accept.
+
+    OpenAlex answers budget-exhausted requests with 429 and a Retry-After
+    spanning hours (the time left to the midnight-UTC budget reset).
+    urllib3 honors Retry-After by default, which would silently freeze the
+    caller inside a sleep; requests that hit it raise this error
+    immediately instead.
+    """
+
+
+class OpenAlexRetry(Retry):
+    """Retry policy that refuses to sleep on very large Retry-After values.
+
+    Retry-After values up to RETRY_AFTER_MAX seconds (transient rate
+    limiting) are honored as usual; anything above it raises
+    RateLimitError.
+    """
+
+    RETRY_AFTER_MAX = 300  # seconds
+
+    def get_retry_after(self, response):
+        retry_after = super().get_retry_after(response)
+        if retry_after is not None and retry_after > self.RETRY_AFTER_MAX:
+            raise RateLimitError(
+                f"Server asked to retry after {retry_after:.0f}s "
+                f"(> {self.RETRY_AFTER_MAX}s) — on OpenAlex this means the "
+                "daily request budget is exhausted (it resets at midnight "
+                "UTC). Failing fast instead of sleeping."
+            )
+        return retry_after
+
+
 def _get_requests_session():
     """Create a Requests session with automatic retry.
 
@@ -213,7 +246,7 @@ def _get_requests_session():
     """
     # create an Requests Session with automatic retry:
     requests_session = requests.Session()
-    retries = Retry(
+    retries = OpenAlexRetry(
         total=config.max_retries,
         backoff_factor=config.retry_backoff_factor,
         status_forcelist=config.retry_http_codes,

--- a/tests/test_pyalex.py
+++ b/tests/test_pyalex.py
@@ -232,6 +232,23 @@ def test_query_error():
         Works().filter(publication_year_error=2020).get()
 
 
+def test_retry_after_cap():
+    """A huge Retry-After (exhausted daily budget) raises instead of sleeping."""
+    import urllib3
+
+    from pyalex.api import OpenAlexRetry
+    from pyalex.api import RateLimitError
+
+    # short Retry-After (transient rate limiting) is honored as usual
+    resp = urllib3.HTTPResponse(headers={"Retry-After": "30"})
+    assert OpenAlexRetry().get_retry_after(resp) == 30
+
+    # hours-long Retry-After fails fast
+    resp = urllib3.HTTPResponse(headers={"Retry-After": "53578"})
+    with pytest.raises(RateLimitError):
+        OpenAlexRetry().get_retry_after(resp)
+
+
 @requires_api_key(reason="OpenAlex requires authentication for filter queries")
 def test_data_publications():
     w = (


### PR DESCRIPTION
## Problem

When an OpenAlex API key's daily budget is exhausted, the API answers every request with 429 plus a `Retry-After` header spanning **hours** (the time left to the midnight-UTC budget reset — I observed `Retry-After: 53578`, ~14.9 h, body: *"Insufficient budget … Resets at midnight UTC"*).

urllib3's `Retry` honors `Retry-After` by default, so with 429 in `retry_http_codes` the calling thread goes into `time.sleep(53578)` **inside the request call** — no exception, no log output. In a notebook or worker thread this is indistinguishable from a hang; with `max_retries` set high it can nominally sleep for days.

## Change

- `OpenAlexRetry(Retry)`: honors `Retry-After` up to `RETRY_AFTER_MAX = 300` s, so genuine transient rate limiting keeps working exactly as before; anything above raises the new `RateLimitError` with a message explaining that the daily budget is exhausted and when it resets.
- `_get_requests_session()` uses `OpenAlexRetry` in place of `Retry`. No other behavior changes.
- `test_retry_after_cap`: offline test (no network, no API key) covering both sides of the cap.

Verified against the live API with an actually-exhausted key: the request now raises `RateLimitError` in 0.3 s instead of freezing until midnight UTC.

Companion to #109 (request timeouts): #109 bounds requests that never get a response; this bounds the sleep urllib3 performs after a response that says "come back in 15 hours". The two are independent and touch different code, so they can be merged in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)